### PR TITLE
Configuration driven off a yaml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ cython_debug/
 
 # version file (managed by setuptools-scm)
 src/wbi/_version.py
+.DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ classifiers = [
 ]
 dependencies = [
     "jinja2",
-    "paramiko"
+    "paramiko",
+    "pyyaml"
 ]
 
 [project.scripts]

--- a/src/wbi/__init__.py
+++ b/src/wbi/__init__.py
@@ -1,5 +1,8 @@
+from importlib.resources import files
 import os
 import logging.config
+import wbi
+from wbi.configuration import Config
 
 # The _version.py file is managed by setuptools-scm
 #   and is not in version control.
@@ -31,3 +34,5 @@ logging.config.dictConfig(
         "loggers": {"": {"handlers": ["default"], "level": "INFO"}},
     }
 )
+
+config = Config("wbi", files(wbi) / "config.yaml")

--- a/src/wbi/commands/hello.py
+++ b/src/wbi/commands/hello.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+from wbi import config
 
 
 logger = logging.getLogger(__name__)
@@ -7,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 def add_args(parser):
     parser.add_argument(
-        "--greeting", type=str, default="Hello", help="Greeting to print"
+        "--greeting", type=str, default=config.test.string, help="Greeting to print"
     )
     parser.add_argument(
         "-v", "--verbose", action="store_true", help="Increase verbosity"

--- a/src/wbi/config.yaml
+++ b/src/wbi/config.yaml
@@ -1,0 +1,15 @@
+ # General package configuration can go here
+
+ # A key purely for testing purposes
+ test:
+   string: "Hello"
+   int: 42
+   float: 3.141592653589793
+   none: null
+   nested:
+     bool: true
+     list:
+       - "Blinky"
+       - "Pinky"
+       - "Inky"
+       - "Clyde"

--- a/src/wbi/configuration.py
+++ b/src/wbi/configuration.py
@@ -1,0 +1,32 @@
+import yaml
+
+
+# https://stackoverflow.com/questions/38034377/object-like-attribute-access-for-nested-dictionary
+class AttrDict(dict):
+    def __init__(self, *args, **kwargs):
+        super(AttrDict, self).__init__(*args, **kwargs)
+        self.__dict__ = self
+
+    @classmethod
+    def from_nested_dicts(cls, data):
+        """Construct nested AttrDicts from nested dictionaries."""
+        if not isinstance(data, dict):
+            return data
+        else:
+            return cls({key: cls.from_nested_dicts(data[key]) for key in data})
+
+
+class Config(object):
+    def __init__(self, name, filepath):
+        self.name = name
+        self.namespace = None
+        self.file_paths = [filepath]
+        self.init_from_file(filepath)
+
+    def __getattr__(self, item):
+        return getattr(self.namespace, item)
+
+    def init_from_file(self, filepath):
+        with open(filepath) as f:
+            attr_dict = yaml.load(f, Loader=yaml.FullLoader)
+        self.namespace = AttrDict.from_nested_dicts(attr_dict)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,27 @@
+import math
+from wbi import config
+
+
+def test_str():
+    assert config.test.string == "Hello"
+
+
+def test_int():
+    assert config.test.int == 42
+
+
+def test_float():
+    assert math.isclose(config.test.float, math.pi)
+
+
+def test_none():
+    assert config.test.none is None
+
+
+def test_nested_bool():
+    assert config.test.nested.bool is True
+
+
+def test_nested_list():
+    assert len(config.test.nested.list) == 4
+    assert config.test.nested.list[2] == "Inky"


### PR DESCRIPTION
For a large project like this, we're going to be using "magical" numbers and configuration settings all over place. Instead of spreading around these values across our code, something like a `config.yaml` file will allow us to collect all of these in one place, and allow us to use (as a made up example), `config.flash_finder.interval` in our code if we need to access it.

The contained unit tests show how to use this.

I've used `.ini`, `.json` files etc. over the years, but realized that `.yaml` is the best in terms of flexibility - arbitrarily nested structures, lists etc, along with comments (json doesn't have support for comments so it's a big pain).

This also shows how to use `importlib_resources` to access data files that we package with our code.

This PR will likely fail because `config.yaml` is not being packaged with our code. If you can fix this, that would be great.