### PR TITLE
Made hello remote template simpler

### DIFF
--- a/src/wbi/remote/templates/hello.jinja
+++ b/src/wbi/remote/templates/hello.jinja
@@ -6,4 +6,4 @@
 #SBATCH --cpus-per-task=1
 #SBATCH --mem-per-cpu=16M
 
-python -c "import socket; print('Hello ' + socket.gethostname());"
+echo "Hello $(hostname)"


### PR DESCRIPTION
Modified the hello template - `hello.jinja` to only use bash. Successfully split the previous branch `vb/remote` based on three commits and reverted it back to original.