### PR TITLE
remote execution simplification by using srun when interactive

### DIFF
--- a/src/wbi/commands/remote.py
+++ b/src/wbi/commands/remote.py
@@ -1,10 +1,5 @@
 import argparse
-import logging
-import paramiko
-import time
-from wbi.remote.remote import submit, parse_remote_stdout
-
-logger = logging.getLogger(__name__)
+from wbi.remote.remote import submit
 
 
 def add_args(parser):
@@ -18,51 +13,53 @@ def add_args(parser):
         "--template",
         type=str,
         default="hello",
-        help="Template to use for job script (default: hello)",
+        help="Template to use for job script (default: %(default)s)",
     )
     parser.add_argument(
         "--cluster",
         default=False,
         action="store_true",
-        help="Specify if you want to execute command using sbatch",
+        help="Specify if you want to execute command using srun/sbatch",
     )
     parser.add_argument(
-        "-v", "--verbose", action="store_true", help="Increase verbosity"
+        "--timelimit",
+        type=str,
+        default=None,
+        help="Time limit string to pass to slurm (--cluster mode only)",
+    )
+    parser.add_argument(
+        "--interactive",
+        default=False,
+        action="store_true",
+        help="Monitor and wait for job to finish (--cluster mode only)",
+    )
+    parser.add_argument(
+        "--no-stdout",
+        default=False,
+        action="store_true",
+        help="Suppress remote stdout",
+    )
+    parser.add_argument(
+        "--stderr",
+        default=False,
+        action="store_true",
+        help="Show remote stderr",
     )
 
     return parser
 
 
-def setup_ssh_client(hostname, username):
-    client = paramiko.SSHClient()
-    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    client.connect(hostname, username=username)
-    return client
-
-
-def monitor_job(client, remote_temp_stdout_path):
-    while True:
-        stdout = parse_remote_stdout(client, remote_temp_stdout_path)
-        if stdout in (None, ""):
-            logger.info("No job output available yet. Waiting...")
-            time.sleep(5)
-        else:
-            break
-    logger.info(stdout)
-
-
 def main(args):
-    client = setup_ssh_client(args.hostname, args.username)
-
-    job_id, remote_temp_stdout_path = submit(
-        template_name=args.template, mins=1, client=client, cluster=args.cluster
+    submit(
+        template_name=args.template,
+        timelimit=args.timelimit,
+        hostname=args.hostname,
+        username=args.username,
+        cluster=args.cluster,
+        interactive=args.interactive,
+        show_stdout=not args.no_stdout,
+        show_stderr=args.stderr,
     )
-    if args.cluster:
-        logger.info(f"Submitted job with ID {job_id}")
-    logger.info(f"Remote stdout path: {remote_temp_stdout_path}")
-    monitor_job(client, remote_temp_stdout_path)
-
-    client.close()
 
 
 if __name__ == "__main__":

--- a/src/wbi/remote/templates/hello.jinja
+++ b/src/wbi/remote/templates/hello.jinja
@@ -1,5 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=wbi-{{ template_name }}
+#SBATCH --time={{ timelimit or '00:01:00' }}
 
 #SBATCH --nodes=1
 #SBATCH --tasks-per-node=1

--- a/src/wbi/remote/templates/pyhello.jinja
+++ b/src/wbi/remote/templates/pyhello.jinja
@@ -1,5 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=wbi-{{ template_name }}
+#SBATCH --time={{ timelimit or '00:01:00' }}
 
 #SBATCH --nodes=1
 #SBATCH --tasks-per-node=1

--- a/src/wbi/remote/templates/ray.jinja
+++ b/src/wbi/remote/templates/ray.jinja
@@ -1,5 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=ray-cluster-job
+#SBATCH --time={{ timelimit or '00:10:00' }}
 
 #SBATCH --nodes=3
 ##SBATCH --exclusive


### PR DESCRIPTION
When running `wbi remote` command, we should have an option of running them interactively or just logging the job id and being done with it. This PR adds this.

There are some simplifications when monitoring the job (if running interactively) - we can/should use `srun` in such cases instead of `sbatch`.

The other code tweaks here have to do with specifying `--time=...` flag for `srun` and `sbatch`. `srun` insists that we specify it, so we pass on the responsibility to the user of the `wbi remote` command. This will also override the defaults in the `sbatch` case. Otherwise, the defaults specified in the relevant template files are used.