### PR TITLE
Issue 31: Run tests on "real" data

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+    expensive: marks tests as expensive to run (deselect with '-m "not expensive"')
+
+addopts = -m "not expensive"

--- a/src/wbi/data/ondemand.py
+++ b/src/wbi/data/ondemand.py
@@ -12,14 +12,34 @@ Large files that are downloaded/cached automagically using the pooch library.
 """
 
 files = {
-    "best_model": {
+    "best_model.h5": {
         "url": "https://dl.dropboxusercontent.com/scl/fi/jphaqhoci2fae0tmy0gna/best_model.h5?rlkey=w7tbd1woo8yafzq1m1djlf2um&dl=1",
         "hash": "md5:4feda1bad12dccfd1ab333bda7bf19dc",
-    }
+    },
+    "sCMOS_Frames_U16_1024x512.dat": {
+        "url": "https://dl.dropboxusercontent.com/scl/fi/j18s8hfj30ou26hg82g45/sCMOS_Frames_U16_1024x512.dat?rlkey=eqivmm1o8wd4m34wjml64rc52&dl=0",
+        "hash": "md5:e5d9d9437a77f5d28b90fc03b2f43d9a",
+    },
+    "framesDetails.txt": {
+        "url": "https://dl.dropboxusercontent.com/scl/fi/y4yj624x96r1bcqinoged/framesDetails.txt?rlkey=8m8kdp4tozeiwdyxpm8z4you1&dl=0",
+        "hash": "md5:e65422d0ca888c3fcee6ecbff3cb62a8",
+    },
+    "other-frameSynchronous.txt": {
+        "url": "https://dl.dropboxusercontent.com/scl/fi/anusvpiiyrrhemr1bscod/other-frameSynchronous.txt?rlkey=qqa3e9n3g1fp1lm8568v022hz&dl=0",
+        "hash": "md5:d39e74b65e2b3907a3182b52012dfc42",
+    },
+    "other-volumeMetadataUtilities.txt": {
+        "url": "https://dl.dropboxusercontent.com/scl/fi/c7clmlqqcxsy8wasdlmi8/other-volumeMetadataUtilities.txt?rlkey=lseq3jjm61qtjol1glk8mxwwq&dl=0",
+        "hash": "md5:ce1ef0aea3bb8af25499d74241c941c8",
+    },
+    "LowMagBrain20231024_153442": {
+        "url": "https://www.dropbox.com/scl/fo/oqgj6jhaz4wixhxi1riec/h?rlkey=7bgjwlx496oxi00chq4144tfs&dl=1",
+        "hash": None,
+    },
 }
 
 
 def get_file(which):
     assert which in files, f"Unknown file {which}"
     file = files[which]
-    return pooch.retrieve(url=file["url"], known_hash=file["hash"])
+    return pooch.retrieve(url=file["url"], known_hash=file["hash"], fname=which)

--- a/src/wbi/legacy/make_centerline.py
+++ b/src/wbi/legacy/make_centerline.py
@@ -51,7 +51,7 @@ def clineFromVideo(path_cam, output_folder=None,plot=False, max_frames=None):
     if max_frames is not None:
         frame_count = min(frame_count, max_frames)
 
-    model = load_model(get_file("best_model"))
+    model = load_model(get_file("best_model.h5"))
 
     # create a new folder containing the centerline images frame-by-frame
 

--- a/tests/long_running_tests/test_expensive_experiment.py
+++ b/tests/long_running_tests/test_expensive_experiment.py
@@ -1,9 +1,11 @@
 import tempfile
 import os.path
+import pytest
 from wbi.experiment import Experiment
 from wbi.data.ondemand import get_file
 
 
+@pytest.mark.expensive
 def test_flash_finder():
     files = [
         "framesDetails.txt",

--- a/tests/long_running_tests/test_experiment.py
+++ b/tests/long_running_tests/test_experiment.py
@@ -1,0 +1,36 @@
+import tempfile
+import os.path
+from wbi.experiment import Experiment
+from wbi.data.ondemand import get_file
+
+
+def test_flash_finder():
+    files = [
+        "framesDetails.txt",
+        "LowMagBrain20231024_153442",
+        "other-frameSynchronous.txt",
+        "other-volumeMetadataUtilities.txt",
+        "sCMOS_Frames_U16_1024x512.dat",
+    ]
+    with tempfile.TemporaryDirectory() as temp_dir:
+        data_folder = os.path.dirname(list(map(get_file, files))[0])
+        e = Experiment(data_folder)
+        mat_data = e.flash_finder(
+            output_folder=temp_dir,
+        )
+
+        flash_time = list(
+            [
+                [index[0], mat_data["frameTime"][index][0][0]]
+                for index in mat_data["flashLoc"]
+            ]
+        )
+        assert flash_time == [
+            [2487, 150.719],
+            [2702, 151.796],
+            [2910, 152.848],
+            [55739, 418.586],
+            [55962, 419.703],
+            [56177, 420.79],
+            [56238, 421.095],
+        ]


### PR DESCRIPTION
1. Retrieves following files from dropbox: 
```
      - sCMOS_Frames_U16_1024x512.dat
      - framesDetails.txt
      - other-frameSynchronous.txt
      - other-volumeMetadataUtilities.txt
      - LowMagBrain20231024_153442
```
2. Tests flash location with specific flash times 
3. Includes`pytest.ini` to account for expensive tests