### PR TITLE
[skip ci] better organization of nested expensive data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,8 @@ wbi = ["config.yaml", "data/*"]
 write_to = "src/wbi/_version.py"
 
 [tool.pytest.ini_options]
-testpaths = [
-    "tests"
-]
+testpaths = ["tests"]
+norecursedirs = ["long_running_tests"]
 
 [tool.pyright]
 exclude = ["src/wbi/legacy", "matlab/", "build/"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-markers =
-    expensive: marks tests as expensive to run (deselect with '-m "not expensive"')
-
-addopts = -m "not expensive"

--- a/src/wbi/data/ondemand.py
+++ b/src/wbi/data/ondemand.py
@@ -11,30 +11,33 @@ Large files that are downloaded/cached automagically using the pooch library.
     replace "dl=0" with "dl=1"
 """
 
+CACHE_PATH = pooch.os_cache("wbi")
+
 files = {
     "best_model.h5": {
         "url": "https://dl.dropboxusercontent.com/scl/fi/jphaqhoci2fae0tmy0gna/best_model.h5?rlkey=w7tbd1woo8yafzq1m1djlf2um&dl=1",
         "hash": "md5:4feda1bad12dccfd1ab333bda7bf19dc",
     },
-    "sCMOS_Frames_U16_1024x512.dat": {
+    "bs/sCMOS_Frames_U16_1024x512.dat": {
         "url": "https://dl.dropboxusercontent.com/scl/fi/j18s8hfj30ou26hg82g45/sCMOS_Frames_U16_1024x512.dat?rlkey=eqivmm1o8wd4m34wjml64rc52&dl=0",
-        "hash": "md5:e5d9d9437a77f5d28b90fc03b2f43d9a",
+        "hash": None,
     },
-    "framesDetails.txt": {
+    "bs/framesDetails.txt": {
         "url": "https://dl.dropboxusercontent.com/scl/fi/y4yj624x96r1bcqinoged/framesDetails.txt?rlkey=8m8kdp4tozeiwdyxpm8z4you1&dl=0",
         "hash": "md5:e65422d0ca888c3fcee6ecbff3cb62a8",
     },
-    "other-frameSynchronous.txt": {
+    "bs/other-frameSynchronous.txt": {
         "url": "https://dl.dropboxusercontent.com/scl/fi/anusvpiiyrrhemr1bscod/other-frameSynchronous.txt?rlkey=qqa3e9n3g1fp1lm8568v022hz&dl=0",
         "hash": "md5:d39e74b65e2b3907a3182b52012dfc42",
     },
-    "other-volumeMetadataUtilities.txt": {
+    "bs/other-volumeMetadataUtilities.txt": {
         "url": "https://dl.dropboxusercontent.com/scl/fi/c7clmlqqcxsy8wasdlmi8/other-volumeMetadataUtilities.txt?rlkey=lseq3jjm61qtjol1glk8mxwwq&dl=0",
         "hash": "md5:ce1ef0aea3bb8af25499d74241c941c8",
     },
-    "LowMagBrain20231024_153442": {
+    "bs/LowMagBrain20231024_153442": {
         "url": "https://www.dropbox.com/scl/fo/oqgj6jhaz4wixhxi1riec/h?rlkey=7bgjwlx496oxi00chq4144tfs&dl=1",
-        "hash": None,
+        "hash": "md5:6e91298ff0fc9e37fde8e35c58c5d110",
+        "processor": pooch.Unzip(),
     },
 }
 
@@ -42,4 +45,10 @@ files = {
 def get_file(which):
     assert which in files, f"Unknown file {which}"
     file = files[which]
-    return pooch.retrieve(url=file["url"], known_hash=file["hash"], fname=which)
+    return pooch.retrieve(
+        url=file["url"],
+        known_hash=file["hash"],
+        fname=which,
+        processor=file.get("processor"),
+        path=CACHE_PATH,
+    )

--- a/src/wbi/experiment.py
+++ b/src/wbi/experiment.py
@@ -22,7 +22,7 @@ class Experiment:
         self.frames_sync = FrameSynchronous(folder_path)
         self.timing_dataframe = self.timing.merge_sync(self.frames_sync)
 
-        lowmag_folders = glob.glob(f"{folder_path}/LowMagBrain*")
+        lowmag_folders = glob.glob(f"{folder_path}/LowMagBrain*/")
         if len(lowmag_folders) != 1:
             raise RuntimeError(f"Cannot find LowMagBrain* folder in {folder_path}")
         self.lowmag_folder = lowmag_folders[0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import os.path
 import pytest
-from wbi.data.ondemand import CACHE_PATH
+from wbi.data.ondemand import get_file
 
 
 @pytest.fixture(scope="session")
@@ -10,4 +10,12 @@ def data_folder():
 
 @pytest.fixture(scope="session")
 def expensive_data_folder():
-    return os.path.join(CACHE_PATH, "bs")
+    files = [
+        "bs/sCMOS_Frames_U16_1024x512.dat",
+        "bs/framesDetails.txt",
+        "bs/other-frameSynchronous.txt",
+        "bs/other-volumeMetadataUtilities.txt",
+        "bs/LowMagBrain20231024_153442",
+    ]
+    data_folder = os.path.dirname(list(map(get_file, files))[0])
+    return data_folder

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,13 @@
 import os.path
 import pytest
+from wbi.data.ondemand import CACHE_PATH
 
 
 @pytest.fixture(scope="session")
 def data_folder():
     return os.path.join(os.path.dirname(__file__), "test_data")
+
+
+@pytest.fixture(scope="session")
+def expensive_data_folder():
+    return os.path.join(CACHE_PATH, "bs")

--- a/tests/long_running_tests/test_expensive_experiment.py
+++ b/tests/long_running_tests/test_expensive_experiment.py
@@ -1,22 +1,12 @@
 import tempfile
-import os.path
 import pytest
 from wbi.experiment import Experiment
-from wbi.data.ondemand import get_file
 
 
 @pytest.mark.expensive
-def test_flash_finder():
-    files = [
-        "framesDetails.txt",
-        "LowMagBrain20231024_153442",
-        "other-frameSynchronous.txt",
-        "other-volumeMetadataUtilities.txt",
-        "sCMOS_Frames_U16_1024x512.dat",
-    ]
+def test_flash_finder(expensive_data_folder):
     with tempfile.TemporaryDirectory() as temp_dir:
-        data_folder = os.path.dirname(list(map(get_file, files))[0])
-        e = Experiment(data_folder)
+        e = Experiment(expensive_data_folder)
         mat_data = e.flash_finder(
             output_folder=temp_dir,
         )

--- a/tests/long_running_tests/test_expensive_experiment.py
+++ b/tests/long_running_tests/test_expensive_experiment.py
@@ -1,9 +1,7 @@
 import tempfile
-import pytest
 from wbi.experiment import Experiment
 
 
-@pytest.mark.expensive
 def test_flash_finder(expensive_data_folder):
     with tempfile.TemporaryDirectory() as temp_dir:
         e = Experiment(expensive_data_folder)


### PR DESCRIPTION
- Since we're likely to have more test data in the future that pertain to individual experiments (I can think of the two `/bs` and `/bsa` folders right now), it's better to download/extract data from dropbox in isolated folders. Hence the `bs/` prefix in certain entries.
- Using the `wbi` folder inside the cache folder so we don't clash with anyone else using `pooch`.
- Using fixtures in pytest is a clean way to do this. Session-scoped fixtures are executed only if used, and executed once.
- Skipping CI because I'm not sure what `pytest` will want to run by default in this transition phase.
- My cache folder looks like (in case you want to prepare it beforehand to avoid downloading):
```
(wbi) vineetb@t15p:~/.cache/wbi$ tree
.
├── best_model.h5
├── bs
│   ├── framesDetails.txt
│   ├── hiResData.mat
│   ├── LowMagBrain20231024_153442.unzip
│   │   ├── cam1.avi
│   │   ├── cam1flashTrack.mat
│   │   └── CamData.txt
│   ├── other-frameSynchronous.txt
│   ├── other-volumeMetadataUtilities.txt
│   └── sCMOS_Frames_U16_1024x512.dat -> /media/vineetb/T7/projects/leiferlab/data/.dvc/cache/files/md5/e5/d9d9437a77f5d28b90fc03b2f43d9a
├── framesDetails.txt
└── LowMagBrain20231024_153442

2 directories, 11 files

```