### PR TITLE
Implemented inheritance on jinja templates

### DIFF
--- a/src/wbi/remote/templates/align.jinja
+++ b/src/wbi/remote/templates/align.jinja
@@ -1,13 +1,7 @@
-#!/bin/bash
-#SBATCH --job-name=wbi-{{ template_name }}
-#SBATCH --time={{ timelimit or '00:20:00' }}
+{% extends "base_template.jinja" %}
 
-#SBATCH --nodes=1
-#SBATCH --tasks-per-node=1
-#SBATCH --cpus-per-task=1
-#SBATCH --mem-per-cpu=16M
-
-module load anaconda3/2023.9
-conda activate /projects/LEIFER/communalCode/wbi/envs/wbi
+{% block command %}
+{{ super() }}
 wbi align --input_folder {{input_folder}} --output_folder {{ output_folder }}
 {%- if background_file %} --background_file {{ background_file }}{% endif %}
+{% endblock %}

--- a/src/wbi/remote/templates/base_template.jinja
+++ b/src/wbi/remote/templates/base_template.jinja
@@ -1,0 +1,13 @@
+#!/bin/bash
+#SBATCH --job-name=wbi-{{ template_name }}
+#SBATCH --time={{ timelimit or '00:20:00' }}
+
+#SBATCH --nodes=1
+#SBATCH --tasks-per-node=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem-per-cpu=16M
+
+{% block command %}
+module load anaconda3/2023.9
+conda activate /projects/LEIFER/communalCode/wbi/envs/wbi
+{% endblock %}

--- a/src/wbi/remote/templates/centerline.jinja
+++ b/src/wbi/remote/templates/centerline.jinja
@@ -1,13 +1,7 @@
-#!/bin/bash
-#SBATCH --job-name=wbi-{{ template_name }}
-#SBATCH --time={{ timelimit or '00:20:00' }}
+{% extends "base_template.jinja" %}
 
-#SBATCH --nodes=1
-#SBATCH --tasks-per-node=1
-#SBATCH --cpus-per-task=1
-#SBATCH --mem-per-cpu=16M
-
-module load anaconda3/2023.9
-conda activate /projects/LEIFER/communalCode/wbi/envs/wbi
+{% block command %}
+{{ super() }}
 wbi centerline --input_folder {{input_folder}} {% if max_frames %} --max-frames {{ max_frames }}{% endif -%}
 {% if plot %} --plot{% endif -%}
+{% endblock %}

--- a/src/wbi/remote/templates/flash_finder.jinja
+++ b/src/wbi/remote/templates/flash_finder.jinja
@@ -1,12 +1,6 @@
-#!/bin/bash
-#SBATCH --job-name=wbi-{{ template_name }}
-#SBATCH --time={{ timelimit or '00:20:00' }}
+{% extends "base_template.jinja" %}
 
-#SBATCH --nodes=1
-#SBATCH --tasks-per-node=1
-#SBATCH --cpus-per-task=1
-#SBATCH --mem-per-cpu=16M
-
-module load anaconda3/2023.9
-conda activate /projects/LEIFER/communalCode/wbi/envs/wbi
+{% block command %}
+{{ super() }}
 wbi flash_finder --input_folder {{input_folder}} --output_folder {{output_folder}} --chunksize {{ chunksize or 4000 }}
+{% endblock %}

--- a/src/wbi/remote/templates/hello.jinja
+++ b/src/wbi/remote/templates/hello.jinja
@@ -1,10 +1,5 @@
-#!/bin/bash
-#SBATCH --job-name=wbi-{{ template_name }}
-#SBATCH --time={{ timelimit or '00:01:00' }}
+{% extends "base_template.jinja" %}
 
-#SBATCH --nodes=1
-#SBATCH --tasks-per-node=1
-#SBATCH --cpus-per-task=1
-#SBATCH --mem-per-cpu=16M
-
+{% block command %}
 echo "{{ greeting or 'Hello' }} $(hostname)"
+{% endblock %}

--- a/src/wbi/remote/templates/pyhello.jinja
+++ b/src/wbi/remote/templates/pyhello.jinja
@@ -1,12 +1,7 @@
-#!/bin/bash
-#SBATCH --job-name=wbi-{{ template_name }}
-#SBATCH --time={{ timelimit or '00:01:00' }}
+{% extends "base_template.jinja" %}
 
-#SBATCH --nodes=1
-#SBATCH --tasks-per-node=1
-#SBATCH --cpus-per-task=1
-#SBATCH --mem-per-cpu=16M
-
+{% block command %}
 module load anaconda3/2023.9
 conda activate /projects/LEIFER/communalCode/wbi/envs/cowsay
-python -c "import socket; import cowsay; cowsay.cow('Hello ' + socket.gethostname());"
+python -c "import socket; import cowsay; cowsay.cow('{{ greeting or Hello }} ' + socket.gethostname());"
+{% endblock %}


### PR DESCRIPTION
-Created a `base_template` with `slurm` job submission specifications and a `jinja block` containing common bash commands used by rest of the templates -  `flash-finder`, `align`, `centerline`
-The rest of the templates will extend the `base_template` and make changes to the command block accordingly